### PR TITLE
修复aiocache 初始化的时候 PASSWORD 为 ''的时候初始化失败的问题

### DIFF
--- a/owllook/config/config.py
+++ b/owllook/config/config.py
@@ -27,9 +27,9 @@ LOGGER = logging.getLogger()
 # aiocache
 REDIS_DICT = dict(
     IS_CACHE=True,
-    REDIS_ENDPOINT="",
+    REDIS_ENDPOINT="localhost",
     REDIS_PORT=6379,
-    PASSWORD="",
+    PASSWORD=None,
     CACHE_DB=0,
     SESSION_DB=1,
     POOLSIZE=10,


### PR DESCRIPTION
https://github.com/howie6879/owllook/blob/52b1ffea941fe8a57177c6ea66c5ea9219d43c60/owllook/server.py#L30-L37

初始化的时候 PASSWORD 为 '' 会失败