### PR TITLE
Solve ranking's compatibility issue with ruia.

### DIFF
--- a/owllook/spiders/zh_ranking.py
+++ b/owllook/spiders/zh_ranking.py
@@ -14,12 +14,8 @@ class RankingItem(Item):
     target_item = TextField(css_select='div.rank_i_p_list')
     ranking_title = TextField(css_select='div.rank_i_p_tit')
     more = AttrField(css_select='div.rank_i_more a', attr='href')
-    book_list = TextField(css_select='div.rank_i_p_list>div.rank_i_li')
-
-
-class NameItem(Item):
-    top_name = TextField(css_select='div.rank_i_bname a.rank_i_l_a_book')
-    other_name = TextField(css_select='div.rank_i_bname a')
+    book_list = TextField(
+        css_select='div.rank_i_bname a:first-child', many=True)
 
 
 class ZHRankingSpider(Spider):
@@ -31,17 +27,13 @@ class ZHRankingSpider(Spider):
         result = []
         res_dic = {}
 
-        items_data = await RankingItem.get_items(html=res.html)
-
-        for item in items_data:
-            each_book_list = []
+        async for item in RankingItem.get_items(html=res.html):
             # 只取排名前十的书籍数据
-            for index, value in enumerate(item.book_list[:10]):
-                item_data = await NameItem.get_item(html_etree=value)
-                name = item_data.top_name or item_data.other_name
+            each_book_list = []
+            for index, name in enumerate(item.book_list[:10]):
                 each_book_list.append({
                     'num': index + 1,
-                    'name': name
+                    'name': name,
                 })
             data = {
                 'title': item.ranking_title,


### PR DESCRIPTION
修复了因新版本的 ruia 的`get_items()` 接口发生变化导致排行榜部分程序无法运行的问题，并重新实现了提取逻辑。
新代码测试结果如下：环境`Python 3.6.5` `ruia==0.4.5`
**起点：**
![image](https://user-images.githubusercontent.com/38835019/52101917-b50b5480-2618-11e9-9c7f-9c4e56d4701d.png)
![image](https://user-images.githubusercontent.com/38835019/52101922-bd638f80-2618-11e9-82e6-16a26a2fa2d1.png)
**纵横：**
![image](https://user-images.githubusercontent.com/38835019/52101932-ca807e80-2618-11e9-8758-c5f270dac98f.png)
